### PR TITLE
Add extra action to produce clang compilation database.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -207,3 +207,8 @@ new_http_archive(
     build_file="third_party/BUILD.jsoncpp",
 )
 
+http_archive(
+    name = "io_bazel",
+    sha256 = "b0269e75b40d87ff87886e5f3432cbf88f70c96f907ab588e6c21b2922d72db0",
+    url = "https://github.com/bazelbuild/bazel/releases/download/0.13.1/bazel-0.13.1-dist.zip",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -198,3 +198,12 @@ http_archive(
     strip_prefix = "glog-2faa186e62d544e930305ffd8f8e507b2054cc9b",
     urls = ["https://github.com/google/glog/archive/2faa186e62d544e930305ffd8f8e507b2054cc9b.zip"],
 )
+
+new_http_archive(
+    name = "startupos_external_jsoncpp",
+    strip_prefix = "jsoncpp-cfab607c0d6d4f4cab7bdde69769964c558913cb",
+    urls = ["https://github.com/open-source-parsers/jsoncpp/archive/cfab607c0d6d4f4cab7bdde69769964c558913cb.zip"],
+    sha256 = "0e0abc6b521a6df8eec5b32593781aa2f2f6f24ea71f8b9d3b504e966c849176",
+    build_file="third_party/BUILD.jsoncpp",
+)
+

--- a/third_party/BUILD.jsoncpp
+++ b/third_party/BUILD.jsoncpp
@@ -1,0 +1,110 @@
+# JsonCpp is a C++ library that allows manipulating JSON values, including
+# serialization and deserialization to and from strings.
+
+licenses(["unencumbered"])
+
+exports_files(["LICENSE"])
+
+JSONCPP_VERSION_DEFINES = [
+    "-DJSONCPP_VERSION_STRING=1.8.4",
+    "-DJSONCPP_VERSION_MAJOR=1",
+    "-DJSONCPP_VERSION_MINOR=8",
+    "-DJSONCPP_VERSION_PATCH=4",
+]
+
+cc_library(
+    name = "jsoncpp",
+    srcs = [
+        "src/lib_json/json_reader.cpp",
+        "src/lib_json/json_tool.h",
+        "src/lib_json/json_value.cpp",
+        "src/lib_json/json_writer.cpp",
+    ],
+    hdrs = [
+        "include/json/allocator.h",
+        "include/json/assertions.h",
+        "include/json/autolink.h",
+        "include/json/config.h",
+        "include/json/features.h",
+        "include/json/forwards.h",
+        "include/json/json.h",
+        "include/json/reader.h",
+        "include/json/value.h",
+        "include/json/version.h",
+        "include/json/writer.h",
+    ],
+    copts = JSONCPP_VERSION_DEFINES,
+    includes = ["include"],
+    textual_hdrs = ["src/lib_json/json_valueiterator.inl"],
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "jsoncpp_test",
+    testonly = 1,
+    srcs = [
+        "src/test_lib_json/jsontest.cpp",
+        "src/test_lib_json/jsontest.h",
+        "src/test_lib_json/main.cpp",
+    ],
+    deps = [":jsoncpp"],
+)
+
+py_test(
+    name = "rununittests",
+    srcs = ["test/rununittests.py"],
+    args = ["$(location :jsoncpp_test)"],
+    data = [":jsoncpp_test"],
+)
+
+cc_binary(
+    name = "jsontest",
+    testonly = 1,
+    srcs = ["src/jsontestrunner/main.cpp"],
+    deps = [":jsoncpp"],
+)
+
+py_binary(
+    name = "runjsontests",
+    testonly = 1,
+    srcs = ["test/runjsontests.py"],
+)
+
+filegroup(
+    name = "test_data_filegroup",
+    testonly = 1,
+    srcs = glob(["test/data/**"]),
+)
+
+genrule(
+    name = "test_data_zip",
+    testonly = 1,
+    srcs = [":test_data_filegroup"],
+    outs = ["test_data.zip"],
+    cmd = "zip -q -j $@ $(locations :test_data_filegroup)",
+)
+
+# test/runjsontests.py runs a glob to find all the tests, so we need to ensure
+# that the files are in the right place. It also expects to be able to create
+# new files in the same directory as the tests. This genrule provides an
+# environment for runjsontests.py to run in.
+genrule(
+    name = "bazel_runjsontests_runner",
+    testonly = 1,
+    outs = ["runjsontests_bazel.sh"],
+    cmd = "echo '#! /bin/sh' >> $@;" +
+          "echo 'mkdir test;' >> $@;" +
+          "echo 'unzip -d test/data -q $$1;' >> $@;" +
+          "echo '$$2 $$3 test/data' >> $@",
+)
+
+sh_test(
+    name = "jsontests",
+    srcs = ["runjsontests_bazel.sh"],
+    args = ["$(location :test_data_zip) $(location :runjsontests) $(location :jsontest)"],
+    data = [
+        ":jsontest",
+        ":runjsontests",
+        ":test_data_zip",
+    ],
+)

--- a/tools/clang_json/BUILD
+++ b/tools/clang_json/BUILD
@@ -1,0 +1,30 @@
+cc_binary(
+    name = "update_compile_database",
+    srcs = ["update_compile_database.cc"],
+    deps = [
+        ":extra_actions_base_cc_proto",
+        "@com_google_protobuf//:protobuf",
+        "@startupos_external_jsoncpp//:jsoncpp",
+    ],
+)
+
+cc_proto_library(
+    name = "extra_actions_base_cc_proto",
+    deps = ["@io_bazel//src/main/protobuf:extra_actions_base_proto"],
+)
+
+action_listener(
+    name = "compile_database_listener",
+    extra_actions = [":compile_database_action"],
+    mnemonics = ["CppCompile"],
+    visibility = ["//visibility:public"],
+)
+
+extra_action(
+    name = "compile_database_action",
+    cmd = "$(location :update_compile_database) " +
+          "$(EXTRA_ACTION_FILE) " +
+          "$(output compile_commands.json.$(ACTION_ID))",
+    out_templates = ["compile_commands.json.$(ACTION_ID)"],
+    tools = [":update_compile_database"],
+)

--- a/tools/clang_json/update_compile_database.cc
+++ b/tools/clang_json/update_compile_database.cc
@@ -1,0 +1,75 @@
+// Run this to produce a clang JSON from a bazel extra action with CppAction.
+//   https://docs.bazel.build/versions/master/be/extra-actions.html
+//   https://clang.llvm.org/docs/JSONCompilationDatabase.html
+// Bazel extra actions are experimental, and the CppAction is currently a native
+// action, while native actions are expected to be replaced with skylark actions
+// some day.
+//
+// Clang JSON compilation database is a way to tell tools that operate on C++
+// how what flags and paths they need in order to parse it.
+
+#include <fstream>
+#include <string>
+
+#include <unistd.h>
+
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/stubs/common.h"
+
+#include "src/main/protobuf/extra_actions_base.pb.h"
+
+#include "include/json/json.h"
+
+// Convert a blaze::ExtraActionInfo that contains a blaze::CppCompileInfo into
+// a clang JSON compilation database.
+int main(int argc, char **argv) {
+  if (argc != 3) {
+    std::cerr << "usage: extra_action_file.proto compile_commands.json\n";
+    std::abort();
+  }
+
+  blaze::ExtraActionInfo info;
+  blaze::CppCompileInfo cpp_info;
+
+  std::ifstream extra_action_file{argv[1]};
+  google::protobuf::io::IstreamInputStream extra_action_istream{
+      &extra_action_file};
+  google::protobuf::io::CodedInputStream extra_action_coded{
+      &extra_action_istream};
+
+  info.ParseFromCodedStream(&extra_action_coded);
+  if (!info.HasExtension(blaze::CppCompileInfo::cpp_compile_info)) {
+    std::cerr << "action has no CppCompileInfo!";
+    std::abort();
+  }
+  cpp_info = info.GetExtension(blaze::CppCompileInfo::cpp_compile_info);
+
+  Json::Value root;
+
+  // The source path is relative to the compilation sandbox. The sandbox
+  // includes other files that the compilation of this file would depend on
+  // (such as header files), but does not contain the rest of the source tree.
+  root["file"] = cpp_info.source_file();
+
+  // Name of the output that bazel is running this action to produce. For
+  // instance, a source file may be used to generate a module file and a .o
+  // file.
+  root["output"] = cpp_info.output_file();
+
+  // Path to the current sandbox. This path is not valid after the extra action
+  // completes.
+  root["directory"] = get_current_dir_name();
+
+  Json::Value arguments;
+  arguments.resize(cpp_info.compiler_option_size());
+  for (auto option : cpp_info.compiler_option()) {
+    arguments.append(option);
+  }
+  root["arguments"] = arguments;
+
+  std::ofstream compilation_database_file{argv[2]};
+  compilation_database_file << root;
+
+  return 0;
+}


### PR DESCRIPTION
Clang compilation database is documented here: https://clang.llvm.org/docs/JSONCompilationDatabase.html

As provided, this isn't immediately useful. Either Bazel will need to emit the path to the source file in a WORKSPACE-relative form so that we can run tools that operate over the whole codebase at once, or you would have to edit update_compile_database.cc to integrate with the clang tool (such as running "clang-tidy", which would then also need to be available in the sandbox) and it could only operate on one source file at a time.