### PR TITLE
Remove `npm install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - checkout:
           <<: *post_checkout
       - restore_cache:
-          key: "v2-bazel_cache"
+          key: "v3-bazel_cache"
       - run: './pre-commit.sh'
       - run: './fix_formatting.sh'
 
@@ -54,11 +54,10 @@ jobs:
           key: "android_sdk"
 
       - restore_cache:
-          key: "v2-bazel_cache"
+          key: "v3-bazel_cache"
 
       - run: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
       - run: bazel info release
-      - run: npm install
       - run: bash .circleci/get-android-sdk.sh
       - run:
           command: ./compile.sh build
@@ -77,7 +76,7 @@ jobs:
           key: "android_sdk"
           paths:
             - "/home/circleci/android_sdk"
-          key: "v2-bazel_cache"
+          key: "v3-bazel_cache"
           paths:
             - "/home/circleci/.cache/bazel/"
 

--- a/commands.txt
+++ b/commands.txt
@@ -1,5 +1,4 @@
 # Build every buildable Bazel target and test every testable target
-# TODO: Until we move to Angular Bazel, execute `npm install` beforehand
 bazel query //... | grep -v ^\/\/third_party | grep -v *node_modules | xargs bazel test
 
 # Format dependencies.yaml

--- a/fix_formatting.sh
+++ b/fix_formatting.sh
@@ -7,8 +7,6 @@
 RED=$(tput setaf 1)
 RESET=$(tput sgr0)
 
-npm install &>/dev/null
-
 bazel run //tools/formatter -- \
 	--path $(pwd) \
 	--java --python --proto --cpp --build \


### PR DESCRIPTION
@oferb I bumped up cache version so that I'm sure `npm install` done previously wouldn't affect this particular build (not likely to happen) & to cache new repos we are using to not re-download them (`@startupos_binaries`, `@protoc`…)