### PR TITLE
Fix false positive `lint` by upgrading libstdc++

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 # We use a docker image as the basis for our build, so that all the toolchains we use
 # are already installed and the build can start running right away. It also guarantees
 # the environment is portable and reproducible on your local machine.
-var_1: &docker_image angular/ngcontainer:0.6.0
+var_1: &docker_image angular/ngcontainer:0.3.2
 
 # Each job will inherit these defaults
 anchor_1: &job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 # We use a docker image as the basis for our build, so that all the toolchains we use
 # are already installed and the build can start running right away. It also guarantees
 # the environment is portable and reproducible on your local machine.
-var_1: &docker_image angular/ngcontainer:0.3.2
+var_1: &docker_image angular/ngcontainer:0.6.0
 
 # Each job will inherit these defaults
 anchor_1: &job_defaults
@@ -31,7 +31,7 @@ jobs:
           key: "v3-bazel_cache"
       - run: './tools/pre-commit.sh'
       - run: sudo apt update
-      - run: sudo apt -y install yapf3 python3-pkg-resources
+      - run: sudo apt -y install yapf3 python3-pkg-resources libstdc++6
       - run: sudo ln -s /usr/bin/yapf3 /usr/bin/yapf
       - run: './tools/deps/check_dependencies.sh'
       - run: './tools/fix_formatting.sh'

--- a/tools/reviewer/local_server/service/code_review.proto
+++ b/tools/reviewer/local_server/service/code_review.proto
@@ -107,7 +107,7 @@ message Thread {
     CODE = 0;
     // Thread on commit (synced from other systems e.g GitHub)
     COMMIT = 1;
-    // Thread on repo (synced from other systems e.g GitHub)    
+    // Thread on repo (synced from other systems e.g GitHub)
     REPO = 2;
     // Thread on whole diff
     DIFF = 3;

--- a/tools/reviewer/reviewer.proto
+++ b/tools/reviewer/reviewer.proto
@@ -44,45 +44,45 @@ message ReviewerConfig {
 
 // A user, a contributor to the Reviewer repos.
 message User {
-    // A unique identifier for a user, e.g GitHub user
-    string id = 1;
-    string first_name = 2;
-    string last_name = 3;
-    string email = 4;
-    string image_url = 5;
-    repeated SocialNetwork social_network = 6;
-    // Skills the user has, e.g programming languages.
-    repeated string skill = 7;
-    // Projects the user works on
-    repeated string project_id = 8;
-    repeated Contribution top_contribution = 9;
+  // A unique identifier for a user, e.g GitHub user
+  string id = 1;
+  string first_name = 2;
+  string last_name = 3;
+  string email = 4;
+  string image_url = 5;
+  repeated SocialNetwork social_network = 6;
+  // Skills the user has, e.g programming languages.
+  repeated string skill = 7;
+  // Projects the user works on
+  repeated string project_id = 8;
+  repeated Contribution top_contribution = 9;
+}
+
+message SocialNetwork {
+  enum Type {
+    NONE = 0;
+    FACEBOOK = 1;
+    TWITTER = 2;
+    LINKEDIN = 3;
   }
-  
-  message SocialNetwork {
-    enum Type {
-      NONE = 0;
-      FACEBOOK = 1;
-      TWITTER = 2;
-      LINKEDIN = 3;
-    }
-    Type type = 1;
-    string url = 2;
-  }
-  
-  message Contribution {
-    string description = 1;
-    // E.g link to a GitHub Pull Request.
-    string url = 2;
-  }
-  
-  message Project {
-    string id = 1;
-    string display_name = 2;
-    string project_url = 3;
-    // Short description
-    string description = 4;
-    // This is redundant since User lists projects, but we don't want to do the calculation
-    // in the front-end. We might add a test to enforce this, or push a better data structure to
-    // Firebase.
-    repeated string user_id = 5;
-  }
+  Type type = 1;
+  string url = 2;
+}
+
+message Contribution {
+  string description = 1;
+  // E.g link to a GitHub Pull Request.
+  string url = 2;
+}
+
+message Project {
+  string id = 1;
+  string display_name = 2;
+  string project_url = 3;
+  // Short description
+  string description = 4;
+  // This is redundant since User lists projects, but we don't want to do the
+  // calculation in the front-end. We might add a test to enforce this, or push
+  // a better data structure to Firebase.
+  repeated string user_id = 5;
+}


### PR DESCRIPTION
`clang-format` was causing it with following log:

```
Process exited with result 1 and output:
/home/circleci/.cache/bazel/_bazel_circleci/9ce5c2144ecf75d11717c0aa41e45a8d/execroot/__main__/bazel-out/k8-fastbuild/bin/tools/formatter/formatter.runfiles/clang_format_bin/file/clang_format_bin: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /home/circleci/.cache/bazel/_bazel_circleci/9ce5c2144ecf75d11717c0aa41e45a8d/execroot/__main__/bazel-out/k8-fastbuild/bin/tools/formatter/formatter.runfiles/clang_format_bin/file/clang_format_bin)
```