### PR TITLE
Remove node_modules from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 bazel-*
 *.iml
 .project
-node_modules


### PR DESCRIPTION
I believe the `node_modules` in the ignore is an artifact of the old process where node_modules was installed as an extra step?

I had an old `node_modules` folder still and it caused build issues until I deleted it. It would be nice if `git status` had told me my working tree was unclean :)