### PR TITLE
D304: Bump up container version for CI to 0.6.0

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -23,11 +23,5 @@ build --experimental_strict_action_env
 # It should save time running the first build
 build --experimental_repository_cache=/home/circleci/bazel_repository_cache
 
-# Workaround https://github.com/bazelbuild/bazel/issues/3645
-# Bazel doesn't calculate the memory ceiling correctly when running under Docker.
-# Limit Bazel to consuming RAM and CPU that fit in CircleCI "medium" class
-# https://circleci.com/docs/2.0/configuration-reference/#resource_class
-build --local_resources=3584,2.0,1.0
-
 # Also limit Bazel's own JVM heap to stay within our 4G container limit
-startup --host_jvm_args=-Xmx2G
+startup --host_jvm_args=-Xmx1G

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -30,4 +30,4 @@ build --experimental_repository_cache=/home/circleci/bazel_repository_cache
 build --local_resources=3584,2.0,1.0
 
 # Also limit Bazel's own JVM heap to stay within our 4G container limit
-startup --host_jvm_args=-Xmx1G
+startup --host_jvm_args=-Xmx2G

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -23,5 +23,11 @@ build --experimental_strict_action_env
 # It should save time running the first build
 build --experimental_repository_cache=/home/circleci/bazel_repository_cache
 
+# Workaround https://github.com/bazelbuild/bazel/issues/3645
+# Bazel doesn't calculate the memory ceiling correctly when running under Docker.
+# Limit Bazel to consuming resources that fit in CircleCI "xlarge" class
+# https://circleci.com/docs/2.0/configuration-reference/#resource_class
+build --local_resources=14336,8.0,1.0
+
 # Also limit Bazel's own JVM heap to stay within our 4G container limit
-startup --host_jvm_args=-Xmx1G
+startup --host_jvm_args=-Xmx2G

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -25,7 +25,13 @@ build --experimental_repository_cache=/home/circleci/bazel_repository_cache
 
 # Workaround https://github.com/bazelbuild/bazel/issues/3645
 # Bazel doesn't calculate the memory ceiling correctly when running under Docker.
+# Limit Bazel to consuming RAM and CPU that fit in CircleCI "medium" class
+# https://circleci.com/docs/2.0/configuration-reference/#resource_class
+build --local_resources=3584,2.0,1.0
+
+# Workaround https://github.com/bazelbuild/bazel/issues/3645
+# Bazel doesn't calculate the memory ceiling correctly when running under Docker.
 # Limit Bazel to consuming 3072M of RAM
 build --local_resources=3072,1.0,1.0
 # Also limit Bazel's own JVM heap to stay within our 4G container limit
-startup --host_jvm_args=-Xmx2G
+startup --host_jvm_args=-Xmx1G

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -29,9 +29,5 @@ build --experimental_repository_cache=/home/circleci/bazel_repository_cache
 # https://circleci.com/docs/2.0/configuration-reference/#resource_class
 build --local_resources=3584,2.0,1.0
 
-# Workaround https://github.com/bazelbuild/bazel/issues/3645
-# Bazel doesn't calculate the memory ceiling correctly when running under Docker.
-# Limit Bazel to consuming 3072M of RAM
-build --local_resources=3072,1.0,1.0
 # Also limit Bazel's own JVM heap to stay within our 4G container limit
 startup --host_jvm_args=-Xmx1G

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 # We use a docker image as the basis for our build, so that all the toolchains we use
 # are already installed and the build can start running right away. It also guarantees
 # the environment is portable and reproducible on your local machine.
-var_1: &docker_image angular/ngcontainer:0.3.2
+var_1: &docker_image angular/ngcontainer:0.6.0
 
 # Each job will inherit these defaults
 anchor_1: &job_defaults
@@ -43,7 +43,7 @@ jobs:
           <<: *post_checkout
 
       - restore_cache:
-          key: "android_sdk"
+          key: "android_sdk_28"
 
       - restore_cache:
           key: "v3-bazel_cache"
@@ -61,7 +61,7 @@ jobs:
             ANDROID_HOME: /home/circleci/android_sdk/
 
       - save_cache:
-          key: "android_sdk"
+          key: "android_sdk_28"
           paths:
             - "/home/circleci/android_sdk"
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,8 +60,8 @@ gmaven_rules()
 # https://docs.bazel.build/versions/master/be/android.html#android_sdk_repository
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 27,
-    build_tools_version = "27.0.3",
+    api_level = 28,
+    build_tools_version = "28.0.3",
 )
 
 http_file(
@@ -180,15 +180,15 @@ http_jar(
 http_file(
     name = "protoc_bin",
     executable = True,
-    sha256 = "84e29b25de6896c6c4b22067fb79472dac13cf54240a7a210ef1cac623f5231d",
-    urls = ["https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip"]
+    sha256 = "6003de742ea3fcf703cfec1cd4a3380fd143081a2eb0e559065563496af27807",
+    urls = ["https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip"]
 )
 
 http_file(
     name = "protoc_bin_osx",
     executable = True,
-    sha256 = "768a42032718accd12e056447b0d93d42ffcdc27d1b0f21fc1e30a900da94842",
-    urls = ["https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-osx-x86_64.zip"]
+    sha256 = "0decc6ce5beed07f8c20361ddeb5ac7666f09cf34572cca530e16814093f9c0c",
+    urls = ["https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-osx-x86_64.zip"]
 )
 
 # clang-format tool download, to be used by Formatter tool

--- a/tools/get_android_sdk.sh
+++ b/tools/get_android_sdk.sh
@@ -32,11 +32,11 @@ else
 fi
 
 
-if [ ! -d "$ANDROID_HOME" ]; then
+if [ ! -d "$ANDROID_HOME"/platforms/android-28 ]; then
 	$DOWNLOAD_COMMAND $URL_BASE/$FILENAME
 	unzip $FILENAME -d $ANDROID_HOME
 	(yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses) || true
-	$ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27" "build-tools;27.0.3"
+	$ANDROID_HOME/tools/bin/sdkmanager "platforms;android-28" "build-tools;28.0.3"
 	echo "Removing $(rm -v $FILENAME)"
 fi
 

--- a/tools/protoc.sh
+++ b/tools/protoc.sh
@@ -4,12 +4,12 @@
 
 platform=$(uname)
 pwd
-find . -iname protoc-3.6.0-osx-x86_64.zip
+find . -iname protoc-3.6.1-osx-x86_64.zip
 
 if [ "$platform" == "Darwin" ]; then
-    ARCHIVE=$(find . -iname protoc-3.6.0-osx-x86_64.zip | head -n1)
+    ARCHIVE=$(find . -iname protoc-3.6.1-osx-x86_64.zip | head -n1)
 elif [ "$platform" == "Linux" ]; then
-    ARCHIVE=$(find . -iname protoc-3.6.0-linux-x86_64.zip | head -n1)
+    ARCHIVE=$(find . -iname protoc-3.6.1-linux-x86_64.zip | head -n1)
 else
     echo "protoc does not have a binary for $platform"
     exit 1

--- a/tools/reviewer/aa/aa_tool.sh
+++ b/tools/reviewer/aa/aa_tool.sh
@@ -26,7 +26,7 @@ function _aa_completions()
     cur_word="${COMP_WORDS[COMP_CWORD]}"
     prev_word="${COMP_WORDS[COMP_CWORD-1]}"
 
-    commands="init workspace diff fix sync snapshot add_repo killserver"
+    commands="init workspace sync diff fix review snapshot submit add_repo patch killserver"
     init_options="--base_path --startupos_repo --user"
     add_repo_options="--url --name"
     diff_options="--reviewers --description --buglink"


### PR DESCRIPTION
Also, set Bazel resources so as to (hopefully) not trigger:
"Worker process quit or closed its stdin stream when we tried to send a WorkRequest"
https://circleci.com/gh/google/startup-os/1827

This is mostly based on Max (vmax@)'s work.