### PR TITLE
Add support for easy bazel version upgrade

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -9,7 +9,7 @@ RESET=$(tput sgr0)
 BAZEL_VERSION=$(cat .bazelversion)
 PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
 BAZEL_BINARY_URL="https://releases.bazel.build/$BAZEL_VERSION/release/bazel-$BAZEL_VERSION-$PLATFORM-x86_64"
-BAZEL_BINARY="$HOME/.startupos/bazel"
+BAZEL_BINARY="$HOME/.startupos/bazel-$BAZEL_VERSION"
 
 if [[ "$PLATFORM" != "darwin" ]] && [[ "$PLATFORM" != "linux" ]]; then
   echo "$RED[!] bazel wrapper cannot download a binary for $PLATFORM""$RESET"
@@ -18,6 +18,7 @@ fi
 
 if [[ ! -x ${BAZEL_BINARY} ]]; then
   echo "$GREEN""Downloading bazel binary""$RESET"
+  rm -f $(dirname ${BAZEL_BINARY})/bazel*
   mkdir -p $(dirname ${BAZEL_BINARY})
   wget ${BAZEL_BINARY_URL} --output-document ${BAZEL_BINARY}
   chmod +x ${BAZEL_BINARY}

--- a/tools/bazel
+++ b/tools/bazel
@@ -6,7 +6,9 @@ RED=$(tput setaf 1)
 GREEN=$(tput setaf 2)
 RESET=$(tput sgr0)
 
-BAZEL_VERSION=$(cat .bazelversion)
+REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
+
+BAZEL_VERSION=$(cat $REPOSITORY_ROOT/.bazelversion)
 PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
 BAZEL_BINARY_URL="https://releases.bazel.build/$BAZEL_VERSION/release/bazel-$BAZEL_VERSION-$PLATFORM-x86_64"
 BAZEL_BINARY="$HOME/.startupos/bazel-$BAZEL_VERSION"


### PR DESCRIPTION
With this change, when the `.bazelversion` file at the root of the repository changes, the new version is downloaded and any old versions are deleted