### PR TITLE
workspacerun update 1.05

### DIFF
--- a/tools/workspacerun/index.js
+++ b/tools/workspacerun/index.js
@@ -32,7 +32,11 @@ for (const app of apps) {
 if (command) {
   // Run app
   exec(command, (err, data) => {
-    process.stdout.write(data);
+    if (err) {
+      throw err;
+    } else {
+      process.stdout.write(data);
+    }
   });
 } else {
   error(`${appName} not found`);

--- a/tools/workspacerun/package.json
+++ b/tools/workspacerun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workspacerun",
   "description": "Workspace apps runner",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "scripts": {
     "start": "node index.js"
   },


### PR DESCRIPTION
`workspacerun` didn't display an error, when protoc wasn't installed.
The update fixes it.