### PR TITLE
Make logging in SubmitterTask class more detailed

### DIFF
--- a/common/repo/GitRepo.java
+++ b/common/repo/GitRepo.java
@@ -510,5 +510,11 @@ public class GitRepo implements Repo {
   public static String getProjectName(String githubUrl) {
     return githubUrl.split("/")[4];
   }
+
+  @Override
+  public String getRepoName() {
+    String repoPath = runCommand("rev-parse --show-toplevel").stdout.trim();
+    return repoPath.substring(repoPath.lastIndexOf('/') + 1);
+  }
 }
 

--- a/common/repo/Repo.java
+++ b/common/repo/Repo.java
@@ -109,5 +109,7 @@ public interface Repo {
   String getMostRecentCommitOfBranch(String branch);
 
   String getMostRecentCommitOfFile(String filename);
+
+  String getRepoName();
 }
 

--- a/tools/reviewer/job/tasks/SubmitterTask.java
+++ b/tools/reviewer/job/tasks/SubmitterTask.java
@@ -186,16 +186,22 @@ public class SubmitterTask implements Task {
     }
 
     if (shouldPush) {
-      boolean allPushesSuccessful = gitRepos.stream().allMatch(repo -> repo.push("master"));
-      if (allPushesSuccessful) {
+      List<String> notPushedRepoNames = new ArrayList<>();
+      for (GitRepo repo : gitRepos) {
+        boolean pushSuccessful = repo.push("master");
+        if (!pushSuccessful) {
+          notPushedRepoNames.add(repo.getRepoName());
+        }
+      }
+      if (notPushedRepoNames.isEmpty()) {
         log.atInfo().log("All repos pushed successfully");
         diff = diff.toBuilder().setStatus(Diff.Status.SUBMITTED).build();
         firestoreClient.setProtoDocument(
             ReviewerConstants.DIFF_COLLECTION, String.valueOf(diff.getId()), diff);
         // TODO: store `SubmitterMergeResult`
       } else {
-        // TODO: find out which one.
-        log.atSevere().log("Some repo pushes failed");
+        notPushedRepoNames.forEach(
+            repoName -> log.atSevere().log("[%s] repo push failed", repoName));
       }
     } else {
       // TODO: Find out which repo caused it.


### PR DESCRIPTION
- Add `getRepoName()` method to `GitRepo` class
- Make logging in SubmitterTask class more detailed (fix `TODO`)